### PR TITLE
When a selector is invalid emit a console warning instead of throwing an...

### DIFF
--- a/src/css-cascade.js
+++ b/src/css-cascade.js
@@ -96,7 +96,7 @@ var cssCascade = {
                             else if(element.mozMatchesSelector) isMatching=element.mozMatchesSelector(selector)
                             else if(element.webkitMatchesSelector) isMatching=element.webkitMatchesSelector(selector)
                             else { throw new Error("wft u no element.matchesSelector?") }
-                        } catch(ex) { debugger; setImmediate(function() { throw ex; }) }
+                        } catch(ex) { cssConsole.warn("Invalid selector " + selector); }
                         
                         if(isMatching) { results.push(subrules[sr]); }
                         


### PR DESCRIPTION
... exception
