### PR TITLE
fixes #56: exception thrown during relayout after scrolling down

### DIFF
--- a/src/css-regions/lib/range-extensions.js
+++ b/src/css-regions/lib/range-extensions.js
@@ -480,6 +480,13 @@ Range.prototype.myGetExtensionRect = function() {
             
             // if we are in the fucking whitespace land, return first line
             var prevSibRect = Node.getClientRects(this.endContainer)[0];
+
+            // In case there is no rect (e.g. when endContainer is textnode containing single newline)
+            // See issue: https://github.com/FremyCompany/css-regions-polyfill/issues/56)
+            if(!prevSibRect) { 
+                prevSibRect={top:0,right:0,bottom:0,left:0,width:0,height:0}; 
+            }
+
             return prevSibRect;
             
         } else {

--- a/src/css-regions/polyfill.js
+++ b/src/css-regions/polyfill.js
@@ -288,13 +288,13 @@ module.exports = (function(window, document) { "use strict";
 				});*/
 			}
 			
-			var fixNullRect = function() {
+			var fixNullRect = function(rect) {
 				if(rect.bottom==0 && rect.top==0 && rect.left==0 && rect.right==0) {
 					
 					var scrollTop = -(document.documentElement.scrollTop || document.body.scrollTop);
 					var scrollLeft = -(document.documentElement.scrollLeft || document.body.scrollLeft);
 					
-					rect = {
+					return {
 						width: 0,
 						heigth: 0,
 						top: scrollTop,
@@ -302,6 +302,8 @@ module.exports = (function(window, document) { "use strict";
 						left: scrollLeft,
 						right: scrollLeft
 					}
+				} else {
+					return rect;
 				}
 			}
 			
@@ -330,7 +332,7 @@ module.exports = (function(window, document) { "use strict";
 			do {
 				
 				// store the current selection rect for fast access
-				var rect = r.myGetExtensionRect(); fixNullRect();
+				var rect = fixNullRect(r.myGetExtensionRect());
 				debug();
 				
 				//
@@ -345,19 +347,18 @@ module.exports = (function(window, document) { "use strict";
 					
 					// look if we can optimize by moving fast forward
 					var nextSibling = r.endContainer.childNodes[r.endOffset];
-					var nextSiblingRect = !nextSibling || Node.getBoundingClientRect(nextSibling);
+					var nextSiblingRect = !nextSibling || fixNullRect(Node.getBoundingClientRect(nextSibling));
 					if(nextSibling && nextSiblingRect.bottom<=pos.top+sizingH) {
 						
 						// if yes, move element by element
 						r.setStartAfter(nextSibling)
 						r.setEndAfter(nextSibling)
 						rect = nextSiblingRect
-						fixNullRect()
 						
 					} else {
 						
 						// otherwise, go char-by-char
-						r.myMoveTowardRight(); rect = r.myGetExtensionRect(); fixNullRect();
+						r.myMoveTowardRight(); rect = fixNullRect(r.myGetExtensionRect());
 						
 					}
 				}
@@ -369,7 +370,7 @@ module.exports = (function(window, document) { "use strict";
 				
 				// move the end point char by char until it's completely in the region
 				while(!(r.endContainer==region && r.endOffset==0) && rect.bottom>pos.top+sizingH) {
-					debug(); r.myMoveOneCharLeft(); rect = r.myGetExtensionRect(); fixNullRect();
+					debug(); r.myMoveOneCharLeft(); rect = fixNullRect(r.myGetExtensionRect());
 				}
 				
 				debug()
@@ -451,7 +452,7 @@ module.exports = (function(window, document) { "use strict";
 								var previousLineBottom = lines[lines.length-2].bottom;
 								r.setEnd(current, current.nodeValue.length);
 								while(rect.bottom>previousLineBottom) {
-									r.myMoveOneCharLeft(); rect = r.myGetExtensionRect(); fixNullRect();
+									r.myMoveOneCharLeft(); rect = fixNullRect(r.myGetExtensionRect());
 								}
 								
 								// make sure we didn't exit the text node by mistake


### PR DESCRIPTION
This contains fixes for both "causes" mentioned in #56.

*Note:* Though so far I strived to keep as much code intact as possible, for this fix I changed `fixNullRect` to require the target rect as parameter and to return the (potentially) fixed rect, instead of changing the `rect` variable directly.
This allows this fix to remain concise and I think it also improves the readability of the code.