### PR TITLE
fixes #60: occasionally css break-properties are ignored

### DIFF
--- a/src/css-regions/lib/helpers.js
+++ b/src/css-regions/lib/helpers.js
@@ -31,6 +31,21 @@ module.exports = (function(window, document) { "use strict";
 			// return that sibling
 			return e.previousSibling;
 		},
+
+		//
+		// returns the previous sibling of the element
+		// or its parent if there are none
+		//
+		getAllLevelPreviousSiblingOrParent: function(e, region) {
+			if(!e || e==region) return null;
+
+			// if it has a previous sibling, return it
+			if (e.previousSibling) return e.previousSibling;
+			
+			// else, if it exists and is not the region, return its parent 
+			if(!e.parentNode || e.parentNode==region) return null;
+			return e.parentNode;
+		},
 		
 		//
 		// prepares the element to become a css region

--- a/src/css-regions/polyfill.js
+++ b/src/css-regions/polyfill.js
@@ -557,7 +557,7 @@ module.exports = (function(window, document) { "use strict";
 					}
 					
 				}
-			} while(current = cssRegionsHelpers.getAllLevelPreviousSibling(current, region));
+			} while(current = cssRegionsHelpers.getAllLevelPreviousSiblingOrParent(current, region));
 			
 			// we're almost done! now, let's collect the ancestors to make some splitting postprocessing
 			var current = r.endContainer; var allAncestors=[];


### PR DESCRIPTION
This fixes the issue in my tests. Instead of some, we now test all elements for the presence of break-before/break-always properties (though not all children, but I guess that is ok)