### PR TITLE
fixes #54, fixes #34: correct new region chain insertion point

### DIFF
--- a/src/css-regions/lib/objectmodel.js
+++ b/src/css-regions/lib/objectmodel.js
@@ -128,14 +128,27 @@ module.exports = (function(window, document, cssRegions) { "use strict";
 	};
 
 	cssRegions.Flow.prototype.addToRegions = function(element) {
+
+		// handle trivial cases real quick
+		var regions = this.regions;
+		if(regions.length==0 || regions[regions.length-1].nextSibling === element) {
+			regions.push(element);
+			return;
+		}
+		if(regions[0].previousSibling === element) {
+			regions.unshift(element);
+			return;
+		}
+		
 		
 		// walk the tree to find an element inside the region chain
-		var regions = this.regions;
+		var currentNodeIndex = -1;
 		var treeWalker = document.createTreeWalker(
 			document.documentElement,
 			NodeFilter.SHOW_ELEMENT,
-			function(node) { 
-				return regions.indexOf(node) >= 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT; 
+			function(node) {
+				console.log('Tree walking: ', node);
+				return (currentNodeIndex = regions.indexOf(node)) >= 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
 			},
 			false
 		);
@@ -147,8 +160,8 @@ module.exports = (function(window, document, cssRegions) { "use strict";
 		if(treeWalker.nextNode()) {
 			
 			// insert the element at his current location
-			regions.splice(this.regions.indexOf(treeWalker.currentNode),0,element);
-			
+			regions.splice(currentNodeIndex,0,element);
+
 		} else {
 			
 			// add the new element to the end of the array

--- a/src/css-regions/lib/objectmodel.js
+++ b/src/css-regions/lib/objectmodel.js
@@ -140,14 +140,12 @@ module.exports = (function(window, document, cssRegions) { "use strict";
 			return;
 		}
 		
-		
 		// walk the tree to find an element inside the region chain
 		var currentNodeIndex = -1;
 		var treeWalker = document.createTreeWalker(
 			document.documentElement,
 			NodeFilter.SHOW_ELEMENT,
 			function(node) {
-				console.log('Tree walking: ', node);
 				return (currentNodeIndex = regions.indexOf(node)) >= 0 ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
 			},
 			false


### PR DESCRIPTION
This PR supersedes #55.

After stumbling upon Issue #34 I realised I missed an important hint concerning the TreeWalker. It actually *can* check child-nodes when using FILTER_SKIP as return value.

Since this was already implemented in the `addToContent`-method right above (not sure how I missed that earlier), it made more sense to me to apply the same solution. Any efficiency differences between this approach and the one I applied in #55 will probably depend too much on the complexity of the DOM-tree to be of any real significance in choosing one over the other.
If the DOM tree is simple, or the new region is inserted a short distance away (above) another, then this approach will be more efficient. Whereas appending a new region below any others, but above a few complex DOM tree branches, will probably be less efficient.

Additionally, since `addToContent` also includes a few sensical shortcuts at the top, I applied these to `addToRegion` as well, since they make equal sense here.