### PR TITLE
If the document has no <head>, create to add our style to

### DIFF
--- a/src/css-regions/polyfill.js
+++ b/src/css-regions/polyfill.js
@@ -798,6 +798,10 @@ module.exports = (function(window, document) { "use strict";
 			s.setAttribute("data-css-no-polyfill", true);
 			s.textContent = CSS_STYLE;
 			var head = document.head || document.getElementsByTagName('head')[0];
+			if (!head) {
+                             head = document.createElement("head");
+                             document.documentElement.insertBefore(head, document.documentElement.firstChild);
+                        }
 			head.appendChild(s);
 			
 			// 


### PR DESCRIPTION
Create document.head if it doesn't exist, as it might not when parsing an XHTML file